### PR TITLE
Find process owner name on Windows

### DIFF
--- a/lacuna/src/main/java/cx/corp/lacuna/Main.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/Main.java
@@ -8,6 +8,7 @@ import cx.corp.lacuna.core.NativeProcess;
 import cx.corp.lacuna.core.NativeProcessEnumerator;
 import cx.corp.lacuna.core.linux.LinuxNativeProcessEnumerator;
 import cx.corp.lacuna.core.windows.WindowsNativeProcessEnumerator;
+import cx.corp.lacuna.core.windows.winapi.Advapi32;
 import cx.corp.lacuna.core.windows.winapi.CamelToPascalCaseFunctionMapper;
 import cx.corp.lacuna.core.windows.winapi.Kernel32;
 import cx.corp.lacuna.core.windows.winapi.Psapi;
@@ -41,7 +42,8 @@ public class Main {
 
         Kernel32 kernel = Native.loadLibrary("Kernel32", Kernel32.class, options);
         Psapi psapi = Native.loadLibrary("Psapi", Psapi.class, options);
+        Advapi32 advapi = Native.loadLibrary("Advapi32", Advapi32.class, options);
 
-        return new WindowsNativeProcessEnumerator(kernel, psapi);
+        return new WindowsNativeProcessEnumerator(kernel, psapi, advapi);
     }
 }

--- a/lacuna/src/main/java/cx/corp/lacuna/core/windows/WindowsNativeProcessEnumerator.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/windows/WindowsNativeProcessEnumerator.java
@@ -5,6 +5,7 @@ import com.sun.jna.ptr.IntByReference;
 import cx.corp.lacuna.core.NativeProcessEnumerator;
 import cx.corp.lacuna.core.NativeProcess;
 import cx.corp.lacuna.core.ProcessEnumerationException;
+import cx.corp.lacuna.core.windows.winapi.Advapi32;
 import cx.corp.lacuna.core.windows.winapi.Kernel32;
 import cx.corp.lacuna.core.windows.winapi.Psapi;
 import cx.corp.lacuna.core.windows.winapi.WinApiConstants;
@@ -15,12 +16,10 @@ import java.util.List;
 public class WindowsNativeProcessEnumerator implements NativeProcessEnumerator {
 
     private final WindowsNativeProcessInfoGatherer infoGatherer;
-    private final Kernel32 kernel;
     private final Psapi psapi;
 
-    public WindowsNativeProcessEnumerator(Kernel32 kernel, Psapi psapi) {
-        this.infoGatherer = new WindowsNativeProcessInfoGatherer(kernel); // todo: inject this some day
-        this.kernel = kernel;
+    public WindowsNativeProcessEnumerator(Kernel32 kernel, Psapi psapi, Advapi32 advapi) {
+        this.infoGatherer = new WindowsNativeProcessInfoGatherer(kernel, advapi); // todo: inject this some day
         this.psapi = psapi;
     }
 

--- a/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/Advapi32.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/Advapi32.java
@@ -1,0 +1,48 @@
+package cx.corp.lacuna.core.windows.winapi;
+
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import com.sun.jna.ptr.ByReference;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.win32.StdCallLibrary;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public interface Advapi32 extends StdCallLibrary {
+    boolean openProcessToken(int processHandle, int desiredAccess, IntByReference tokenHandle);
+
+    boolean getTokenInformation(int token,
+                                int tokenInfoClass,
+                                Pointer user, //TokenOwner[] data,
+                                int tokenInfoBufSize,
+                                IntByReference returnLength);
+
+    boolean lookupAccountSidW(int lpSystemName,
+                            int sid,
+                            char[] outNameBuffer,
+                            IntByReference bufferLengthInChars,
+                            char[] outDomainNameBuffer,
+                              IntByReference domainLengthInChars,
+                            IntByReference outSidNameUse);
+
+    class TokenUser extends Structure {
+
+        // JNA needs these to be public fields :(
+        public int user;
+        public int attributes;
+
+        public TokenUser(Pointer ptr) {
+            user = ptr.getInt(0);
+            attributes = ptr.getInt(4);
+        }
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return new ArrayList<String>() {{
+                add("user");
+                add("attributes");
+            }};
+        }
+    }
+}

--- a/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/WinApiConstants.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/WinApiConstants.java
@@ -16,6 +16,10 @@ public final class WinApiConstants {
      */
     public static final int MAX_FILENAME_LENGTH = 260;
 
+    public static final int MAX_USERNAME_LENGTH = 256;
+
+    public static final int MAX_DOMAIN_NAME_LENGTH = 64;
+
     /** Size of an int on the supported platform.
      */
     public static final int SIZEOF_INT = 4;
@@ -30,4 +34,18 @@ public final class WinApiConstants {
      * native system path format.
      */
     public static final int QUERYFULLPROCESSIMAGENAME_PATHFORMAT_WIN32 = 0;
+
+    /** When used as the {@code desiredAccess} parameter of
+     * {@link Advapi32#openProcessToken(int, int, IntByReference)}, depicts that
+     * the callee is requesting rights to query an access token.
+     */
+    public static final int OPENPROCESSTOKEN_TOKEN_QUERY = 0x0008;
+
+    /** When used as the {@code TokenInformationClass} parameter of
+     * {@link Advapi32#getTokenInformation(int, int, Advapi32.TokenOwner[], IntByReference)},
+     * depicts that the callee is requesting a TokenOwner struct.
+     */
+    public static final int GETTOKENINFORMATION_TOKENUSER = 1;
+
+    public static final int ERROR_INSUFFICIENT_BUFFER = 122;
 }

--- a/lacuna/src/test/java/cx/corp/lacuna/core/windows/WindowsNativeProcessEnumeratorTest.java
+++ b/lacuna/src/test/java/cx/corp/lacuna/core/windows/WindowsNativeProcessEnumeratorTest.java
@@ -23,7 +23,7 @@ public class WindowsNativeProcessEnumeratorTest {
     public void setUp() {
         kernel = new MockKernel32();
         psapi = new MockPsapi();
-        enumerator = new WindowsNativeProcessEnumerator(kernel, psapi);
+        enumerator = new WindowsNativeProcessEnumerator(kernel, psapi, null);
     }
 
     @Test


### PR DESCRIPTION
https://trello.com/c/obRmn985

Process owner information was previously not collected on Windows.
Getting the user's name is quite a mess with the Windows API. Lots of
room for refactoring, at least. If the process can't be opened, no owner
data can be read either. User domain name is discarded, as it's
irrelevant for local memory manipulation.
* Open TOKEN_QUERY access token for the process
* Get the TOKEN_USER information for the access token
* Translate the TOKEN_USER PSID to the user's name