### PR TITLE
Read process memory bytes on Windows

### DIFF
--- a/lacuna/src/main/java/cx/corp/lacuna/Main.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/Main.java
@@ -2,8 +2,12 @@ package cx.corp.lacuna;
 
 import com.sun.jna.FunctionMapper;
 import com.sun.jna.Library;
+import com.sun.jna.Memory;
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.IntByReference;
+import cx.corp.lacuna.core.MemoryReader;
 import cx.corp.lacuna.core.NativeProcess;
 import cx.corp.lacuna.core.NativeProcessEnumerator;
 import cx.corp.lacuna.core.linux.LinuxNativeProcessEnumerator;
@@ -11,7 +15,9 @@ import cx.corp.lacuna.core.windows.WindowsNativeProcessEnumerator;
 import cx.corp.lacuna.core.windows.winapi.Advapi32;
 import cx.corp.lacuna.core.windows.winapi.CamelToPascalCaseFunctionMapper;
 import cx.corp.lacuna.core.windows.winapi.Kernel32;
+import cx.corp.lacuna.core.windows.winapi.ProcessAccessFlags;
 import cx.corp.lacuna.core.windows.winapi.Psapi;
+import cx.corp.lacuna.core.windows.winapi.SystemErrorCode;
 
 import java.util.HashMap;
 import java.util.List;
@@ -20,9 +26,21 @@ import java.util.Map;
 public class Main {
 
     public static void main(String[] args) {
-        NativeProcessEnumerator enumerator = Platform.isWindows()
+       /* NativeProcessEnumerator enumerator = Platform.isWindows()
                 ? bootstrapWindowsEnumerator()
                 : new LinuxNativeProcessEnumerator();
+*/
+        Map<String, Object> options = new HashMap<>();
+        // Use a mapper so that we can use Java-style function names in the interfaces
+        FunctionMapper nameMapper = new CamelToPascalCaseFunctionMapper();
+        options.put(Library.OPTION_FUNCTION_MAPPER, nameMapper);
+
+        Kernel32 kernel = Native.loadLibrary("Kernel32", Kernel32.class, options);
+        Psapi psapi = Native.loadLibrary("Psapi", Psapi.class, options);
+        Advapi32 advapi = Native.loadLibrary("Advapi32", Advapi32.class, options);
+
+        NativeProcessEnumerator enumerator = new WindowsNativeProcessEnumerator(kernel, psapi, advapi);
+
 
         List<NativeProcess> processes = enumerator.getProcesses();
         for (NativeProcess proc : processes) {
@@ -32,6 +50,40 @@ public class Main {
                     proc.getOwner(),
                     proc.getDescription());
         }
+
+        int pid = 16080;
+        int handle = kernel.openProcess(
+                ProcessAccessFlags.QUERY_INFORMATION | ProcessAccessFlags.VIRTUAL_MEMORY_READ,
+                false,
+                pid);
+        Memory buffer = new Memory(20);
+        IntByReference read = new IntByReference(0);
+        boolean success = kernel.readProcessMemory(
+                handle,
+                -1,
+                buffer,
+                (int) buffer.size(),
+                read);
+
+        if (success) {
+            System.out.println("Success");
+            System.out.println(buffer.getInt(0));
+            System.out.println(buffer.getInt(4));
+            System.out.println(buffer.getByte(8));
+            System.out.println(buffer.getByte(9));
+            System.out.println(buffer.getShort(10));
+
+            try {
+                System.out.println(buffer.getInt(12));
+            } catch (Error error) {
+                // Access violation possibly
+                System.out.println(error.toString());
+            }
+        } else {
+            System.out.println("success = " + success);
+            System.out.println("Native.getLastError() = " + SystemErrorCode.fromId(Native.getLastError()).getError());
+        }
+        kernel.closeHandle(handle);
     }
 
     private static NativeProcessEnumerator bootstrapWindowsEnumerator() {

--- a/lacuna/src/main/java/cx/corp/lacuna/Main.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/Main.java
@@ -1,27 +1,20 @@
 package cx.corp.lacuna;
 
-import com.sun.jna.FunctionMapper;
-import com.sun.jna.Library;
-import com.sun.jna.Memory;
-import com.sun.jna.Native;
-import com.sun.jna.Platform;
-import com.sun.jna.Pointer;
+import com.sun.jna.*;
 import com.sun.jna.ptr.IntByReference;
 import cx.corp.lacuna.core.MemoryReader;
 import cx.corp.lacuna.core.NativeProcess;
 import cx.corp.lacuna.core.NativeProcessEnumerator;
 import cx.corp.lacuna.core.linux.LinuxNativeProcessEnumerator;
+import cx.corp.lacuna.core.windows.WindowsMemoryReader;
 import cx.corp.lacuna.core.windows.WindowsNativeProcessEnumerator;
 import cx.corp.lacuna.core.windows.winapi.Advapi32;
 import cx.corp.lacuna.core.windows.winapi.CamelToPascalCaseFunctionMapper;
 import cx.corp.lacuna.core.windows.winapi.Kernel32;
 import cx.corp.lacuna.core.windows.winapi.ProcessAccessFlags;
 import cx.corp.lacuna.core.windows.winapi.Psapi;
-import cx.corp.lacuna.core.windows.winapi.SystemErrorCode;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class Main {
 
@@ -41,7 +34,6 @@ public class Main {
 
         NativeProcessEnumerator enumerator = new WindowsNativeProcessEnumerator(kernel, psapi, advapi);
 
-
         List<NativeProcess> processes = enumerator.getProcesses();
         for (NativeProcess proc : processes) {
             System.out.printf(
@@ -51,39 +43,14 @@ public class Main {
                     proc.getDescription());
         }
 
-        int pid = 16080;
-        int handle = kernel.openProcess(
-                ProcessAccessFlags.QUERY_INFORMATION | ProcessAccessFlags.VIRTUAL_MEMORY_READ,
-                false,
-                pid);
-        Memory buffer = new Memory(20);
-        IntByReference read = new IntByReference(0);
-        boolean success = kernel.readProcessMemory(
-                handle,
-                -1,
-                buffer,
-                (int) buffer.size(),
-                read);
-
-        if (success) {
-            System.out.println("Success");
-            System.out.println(buffer.getInt(0));
-            System.out.println(buffer.getInt(4));
-            System.out.println(buffer.getByte(8));
-            System.out.println(buffer.getByte(9));
-            System.out.println(buffer.getShort(10));
-
-            try {
-                System.out.println(buffer.getInt(12));
-            } catch (Error error) {
-                // Access violation possibly
-                System.out.println(error.toString());
-            }
-        } else {
-            System.out.println("success = " + success);
-            System.out.println("Native.getLastError() = " + SystemErrorCode.fromId(Native.getLastError()).getError());
-        }
-        kernel.closeHandle(handle);
+        MemoryReader reader = new WindowsMemoryReader(kernel);
+        NativeProcess process =
+            processes.stream()
+                .filter(proc -> proc.getDescription().contains("TestTarget"))
+                .findFirst()
+                .get();
+        byte[] bytes = reader.read(process, 0x8AAC38, 16);
+        System.out.println("Arrays.toString(bytes) = " + Arrays.toString(bytes));
     }
 
     private static NativeProcessEnumerator bootstrapWindowsEnumerator() {

--- a/lacuna/src/main/java/cx/corp/lacuna/core/MemoryReadException.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/MemoryReadException.java
@@ -1,0 +1,10 @@
+package cx.corp.lacuna.core;
+
+public class MemoryReadException extends RuntimeException {
+    public MemoryReadException(String msg) {
+        super(msg);
+    }
+    public MemoryReadException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/lacuna/src/main/java/cx/corp/lacuna/core/MemoryReader.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/MemoryReader.java
@@ -1,0 +1,5 @@
+package cx.corp.lacuna.core;
+
+public interface MemoryReader {
+    //byte[] read(NativeProcess process, int offset, )
+}

--- a/lacuna/src/main/java/cx/corp/lacuna/core/MemoryReader.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/MemoryReader.java
@@ -1,5 +1,13 @@
 package cx.corp.lacuna.core;
 
 public interface MemoryReader {
-    //byte[] read(NativeProcess process, int offset, )
+    /** Reads an array of bytes from the memory of the specified {@link NativeProcess}.
+     *
+     * @param process The native process whose memory to read.
+     * @param offset The memory address offset to read from.
+     * @param bytesToRead The amount of bytes to read, starting from the {@code offset}.
+     * @return The read bytes.
+     * @see cx.corp.lacuna.core.NativeProcessEnumerator
+     */
+    byte[] read(NativeProcess process, int offset, int bytesToRead);
 }

--- a/lacuna/src/main/java/cx/corp/lacuna/core/NativeProcess.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/NativeProcess.java
@@ -35,6 +35,8 @@ public class NativeProcess {
     }
 
     /** Sets the process identifier.
+     *
+     * @param pid The process identifier.
      */
     public void setPid(int pid) {
         this.pid = pid;
@@ -42,12 +44,16 @@ public class NativeProcess {
 
     /** Sets the description of the process. The description may be an
      * image name or the command line used to start the process.
+     *
+     * @param description The process description.
      */
     public void setDescription(String description) {
         this.description = description;
     }
 
     /** Sets the name of the owner of the process.
+     *
+     * @param owner The owner of the process.
      */
     public void setOwner(String owner) {
         this.owner = owner;

--- a/lacuna/src/main/java/cx/corp/lacuna/core/ProcessAccessException.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/ProcessAccessException.java
@@ -1,0 +1,12 @@
+package cx.corp.lacuna.core;
+
+public class ProcessAccessException extends RuntimeException {
+
+    public ProcessAccessException(String message) {
+        super(message);
+    }
+
+    public ProcessAccessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/lacuna/src/main/java/cx/corp/lacuna/core/windows/WindowsMemoryReader.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/windows/WindowsMemoryReader.java
@@ -1,0 +1,109 @@
+package cx.corp.lacuna.core.windows;
+
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.ptr.IntByReference;
+import cx.corp.lacuna.core.MemoryReadException;
+import cx.corp.lacuna.core.MemoryReader;
+import cx.corp.lacuna.core.NativeProcess;
+import cx.corp.lacuna.core.ProcessAccessException;
+import cx.corp.lacuna.core.windows.winapi.Kernel32;
+import cx.corp.lacuna.core.windows.winapi.ProcessAccessFlags;
+import cx.corp.lacuna.core.windows.winapi.SystemErrorCode;
+import cx.corp.lacuna.core.windows.winapi.WinApiConstants;
+
+/** {@inheritDoc}
+ * Provides native process memory reading functionality on Windows platforms.
+ */
+public class WindowsMemoryReader implements MemoryReader {
+
+    private static final int FLAGS_READMEMORY =
+            ProcessAccessFlags.QUERY_INFORMATION | ProcessAccessFlags.VIRTUAL_MEMORY_READ;
+
+    private final Kernel32 kernel;
+
+    /** Instantiates a new {@link WindowsMemoryReader} instance using the specified
+     * Kernel32 WindowsAPI proxy.
+     *
+     * @param kernel The Kernel32 WindowsAPI proxy used for process memory reading.
+     */
+    public WindowsMemoryReader(Kernel32 kernel) {
+        this.kernel = kernel;
+    }
+
+    /** {@inheritDoc}
+     *
+     * <p>This method implementation first attempts to open a handle for the specified {@code process}
+     * using the Windows API {@link Kernel32#openProcess(int, boolean, int)} method,
+     * then reads the specified memory segment using the
+     * {@link Kernel32#readProcessMemory(int, int, Memory, int, IntByReference)} method.
+     *
+     * <p>In order to retrieve a {@link NativeProcess} instance, the
+     * {@link cx.corp.lacuna.core.NativeProcessEnumerator} classes can be used.
+     *
+     * <blockquote><pre>{@code
+     * NativeProcessEnumerator enumerator = new WindowsNativeProcessEnumerator(...);
+     * List<NativeProcess> processes = enumerator.getProcesses();
+     * MemoryReader reader = new WindowsMemoryReader(...);
+     *
+     * try {
+     *     byte[] bytes = reader.read(processes[0], 0x1C5B100, 16);
+     *     for (byte b : bytes) {
+     *         System.out.println("%X ", b);
+     *     }
+     * } catch (ProcessAccessException | MemoryReadException ex) {
+     *     System.err.println(ex.toString());
+     *     if (ex.getCause() != null) {
+     *         System.err.println("Cause: " + ex.getCause());
+     *     }
+     * }
+     * }</pre></blockquote>
+     *
+     * @throws ProcessAccessException if the specified process could not be opened for reading.
+     * @throws MemoryReadException if reading the process memory fails.
+     */
+    @Override
+    public byte[] read(NativeProcess process, int offset, int bytesToRead)
+            throws ProcessAccessException, MemoryReadException {
+
+        int handle = kernel.openProcess(FLAGS_READMEMORY, false, process.getPid());
+        if (handle == WinApiConstants.NULLPTR) {
+            throw new ProcessAccessException(
+                    "Process " + process + " could not be opened for reading! System error: "
+                    + Native.getLastError());
+        }
+
+        Memory buffer = new Memory(bytesToRead);
+        IntByReference bytesRead = new IntByReference(0);
+        boolean success = kernel.readProcessMemory(
+                handle,
+                offset,
+                buffer,
+                bytesToRead,
+                bytesRead);
+
+        if (!success) {
+            int errorCode = Native.getLastError();
+            throw createReadExceptionFromErrorCode(errorCode);
+        }
+
+        byte[] ret;
+        try {
+            ret = buffer.getByteArray(0, bytesToRead);
+        } catch (Error err) {
+            // e.g. "Invalid memory access" if reading outside memory bounds.
+            // the Memory class does bounds checking but you can never be sure since
+            // it ultimately calls the natively implemented Native.read method.
+            throw new MemoryReadException(
+                    "An error occurred while reading memory. Use getCause() to get the cause.",
+                    err);
+        }
+
+        return ret;
+    }
+
+    private MemoryReadException createReadExceptionFromErrorCode(int nativeError) {
+        SystemErrorCode error = SystemErrorCode.fromId(nativeError);
+        return new MemoryReadException(error.toString());
+    }
+}

--- a/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/Kernel32.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/Kernel32.java
@@ -1,5 +1,6 @@
 package cx.corp.lacuna.core.windows.winapi;
 
+import com.sun.jna.Memory;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.win32.StdCallLibrary;
 
@@ -12,4 +13,10 @@ public interface Kernel32 extends StdCallLibrary {
                                       int dwFlags,
                                       char[] lpExeName,
                                       IntByReference lpdwSize);
+
+    boolean readProcessMemory(int processHandle,
+                              int baseAddress,
+                              Memory buffer,
+                              int bufferSize,
+                              IntByReference bytesRead);
 }

--- a/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/SystemErrorCode.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/SystemErrorCode.java
@@ -1,0 +1,43 @@
+package cx.corp.lacuna.core.windows.winapi;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum SystemErrorCode {
+
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms681381(v=vs.85).aspx
+
+    INSUFFICIENT_BUFFER(122, "The data area passed to a system call is too small"),
+    PARTIAL_COPY(299, "Only part of a ReadProcessMemory or WriteProcessMemory request was completed"),
+    NO_ACCESS(998, "Invalid access to memory location"),
+    UNMAPPED(-1, "This system error message has not been mapped");
+
+    private static final Map<Integer, SystemErrorCode> ID_TO_ERRORCODE;
+    static {
+        ID_TO_ERRORCODE = new HashMap<>();
+        for (SystemErrorCode error : values()) {
+            ID_TO_ERRORCODE.put(error.id, error);
+        }
+    }
+
+    private final int id;
+    private final String error;
+
+    SystemErrorCode(int id, String error) {
+        this.id = id;
+        this.error = error;
+    }
+
+    public static SystemErrorCode fromId(int id) {
+        SystemErrorCode errorCode = ID_TO_ERRORCODE.get(id);
+        return errorCode == null ? UNMAPPED : errorCode;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getError() {
+        return error;
+    }
+}

--- a/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/SystemErrorCode.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/SystemErrorCode.java
@@ -3,41 +3,69 @@ package cx.corp.lacuna.core.windows.winapi;
 import java.util.HashMap;
 import java.util.Map;
 
+/** Defines standard WinAPI system errors with their descriptions.
+ *
+ * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms681381(v=vs.85).aspx">System Error Codes (Windows)</a>
+ */
 public enum SystemErrorCode {
 
-    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms681381(v=vs.85).aspx
-
+    /** 122 - The data area passed to a system call is too small.
+     */
     INSUFFICIENT_BUFFER(122, "The data area passed to a system call is too small"),
+
+    /** 299 - Only part of a ReadProcessMemory or WriteProcessMemory request was completed.
+     */
     PARTIAL_COPY(299, "Only part of a ReadProcessMemory or WriteProcessMemory request was completed"),
-    NO_ACCESS(998, "Invalid access to memory location"),
-    UNMAPPED(-1, "This system error message has not been mapped");
+
+    /** 998 - Invalid access to memory location.
+     */
+    NO_ACCESS(998, "Invalid access to memory location");
 
     private static final Map<Integer, SystemErrorCode> ID_TO_ERRORCODE;
     static {
         ID_TO_ERRORCODE = new HashMap<>();
         for (SystemErrorCode error : values()) {
-            ID_TO_ERRORCODE.put(error.id, error);
+            ID_TO_ERRORCODE.put(error.systemErrorId, error);
         }
     }
 
-    private final int id;
-    private final String error;
+    private final int systemErrorId;
+    private final String description;
 
     SystemErrorCode(int id, String error) {
-        this.id = id;
-        this.error = error;
+        this.systemErrorId = id;
+        this.description = error;
     }
 
+    /** Returns a {@link SystemErrorCode} enum constant with the matching
+     * system error code constant, or {@code null} if none found.
+     *
+     * @param id A WinAPI system description code constant.
+     * @return A matching {@link SystemErrorCode} enum constant or {@code null} if none found.
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms681381(v=vs.85).aspx">System Error Codes (Windows)</a>
+     */
     public static SystemErrorCode fromId(int id) {
-        SystemErrorCode errorCode = ID_TO_ERRORCODE.get(id);
-        return errorCode == null ? UNMAPPED : errorCode;
+        return ID_TO_ERRORCODE.get(id);
     }
 
-    public int getId() {
-        return id;
+    /** Gets the WinAPI system description identifier of the enum constant.
+     *
+     * @return The WinAPI system description identifier.
+     */
+    public int getSystemErrorId() {
+        return systemErrorId;
     }
 
-    public String getError() {
-        return error;
+    /** Gets the description of the system error.
+     *
+     * @return The description of the system error.
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String toString() {
+        return systemErrorId + ": " + description;
     }
 }

--- a/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/WinApiConstants.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/windows/winapi/WinApiConstants.java
@@ -1,5 +1,6 @@
 package cx.corp.lacuna.core.windows.winapi;
 
+import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 
 import java.nio.CharBuffer;
@@ -42,7 +43,7 @@ public final class WinApiConstants {
     public static final int OPENPROCESSTOKEN_TOKEN_QUERY = 0x0008;
 
     /** When used as the {@code TokenInformationClass} parameter of
-     * {@link Advapi32#getTokenInformation(int, int, Advapi32.TokenOwner[], IntByReference)},
+     * {@link Advapi32#getTokenInformation(int, int, Pointer, int, IntByReference)},
      * depicts that the callee is requesting a TokenOwner struct.
      */
     public static final int GETTOKENINFORMATION_TOKENUSER = 1;

--- a/lacuna/src/test/java/cx/corp/lacuna/core/windows/winapi/MockKernel32.java
+++ b/lacuna/src/test/java/cx/corp/lacuna/core/windows/winapi/MockKernel32.java
@@ -1,5 +1,6 @@
 package cx.corp.lacuna.core.windows.winapi;
 
+import com.sun.jna.Memory;
 import com.sun.jna.ptr.IntByReference;
 
 import java.nio.CharBuffer;
@@ -20,6 +21,11 @@ public class MockKernel32 implements Kernel32 {
 
     @Override
     public boolean queryFullProcessImageNameW(int hProcess, int dwFlags, char[] lpExeName, IntByReference lpdwSize) {
+        return false;
+    }
+
+    @Override
+    public boolean readProcessMemory(int processHandle, int baseAddress, Memory buffer, int bufferSize, IntByReference bytesRead) {
         return false;
     }
 }


### PR DESCRIPTION
https://trello.com/c/rEux0KR6

On Windows platforms, NativeProcess memory is read by first opening a
handle for the process, then using ReadProcessMemory to actually read
the bytes. The SystemErrorCode enumeration was added to provide more
helpful error messages for common memory read failure scenarios.

* Open handle with OpenProcess
* Read memory with ReadProcessMemory
* Create byte array with Memory.getByteArray