### PR TITLE
Implement memory reading on Linux

### DIFF
--- a/lacuna/src/main/java/cx/corp/lacuna/core/common/Utilities.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/common/Utilities.java
@@ -1,0 +1,15 @@
+package cx.corp.lacuna.core.common;
+
+public class Utilities {
+    public static int[] copyToFittedArray(int[] array, int actualCount) {
+        int[] fittedArray = new int[actualCount];
+        System.arraycopy(array, 0, fittedArray, 0, actualCount);
+        return fittedArray;
+    }
+
+    public static byte[] copyToFittedArray(byte[] array, int actualCount) {
+        byte[] fittedArray = new byte[actualCount];
+        System.arraycopy(array, 0, fittedArray, 0, actualCount);
+        return fittedArray;
+    }
+}

--- a/lacuna/src/main/java/cx/corp/lacuna/core/linux/LinuxConstants.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/linux/LinuxConstants.java
@@ -1,14 +1,17 @@
 package cx.corp.lacuna.core.linux;
 
-import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class LinuxConstants {
     /** Fallback value of {@code /proc/sys/kernel/pid_max} to use if the file cannot be read.
-     *
+     * <p>
      * {@code man proc(5)} specifies that {@code 32768} is the default value. On 64-bit systems,
      * {@code pid_max} can be set to up to 2^22 (PID_MAX_LIMIT).
      */
     public static final int FALLBACK_PID_MAX = 32768;
 
-    public static final File PID_MAX_FILE = new File("/proc/sys/kernel/pid_max");
+    public static final Path DEFAULT_PROC_ROOT = Paths.get("/proc");
+
+    public static final Path PID_MAX_RELATIVE_PATH = Paths.get("sys/kernel/pid_max");
 }

--- a/lacuna/src/main/java/cx/corp/lacuna/core/linux/LinuxMemoryReader.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/linux/LinuxMemoryReader.java
@@ -1,0 +1,62 @@
+package cx.corp.lacuna.core.linux;
+
+import cx.corp.lacuna.core.MemoryReadException;
+import cx.corp.lacuna.core.MemoryReader;
+import cx.corp.lacuna.core.NativeProcess;
+import cx.corp.lacuna.core.common.Utilities;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+public class LinuxMemoryReader implements MemoryReader {
+
+    private static final String PROC_MEM_FILENAME = "mem";
+    private static final String FILE_MODE = "r";
+
+    private final Path procRoot;
+
+    public LinuxMemoryReader(Path procRoot) {
+        this.procRoot = procRoot;
+    }
+
+    @Override
+    public byte[] read(NativeProcess process, int offset, int bytesToRead) {
+        File memFile = getProcessMemFile(process);
+
+        byte[] bytes = new byte[bytesToRead];
+        int actuallyRead = 0;
+
+        try (RandomAccessFile stream = new RandomAccessFile(memFile, FILE_MODE)) {
+            stream.seek(offset);
+            actuallyRead = stream.read(bytes, 0, bytesToRead);
+        } catch (IOException ex) {
+            String msg =
+                    "Reading process memory failed, see getCause()! Memory path is "
+                    + memFile + ".";
+            throw new MemoryReadException(msg, ex);
+        }
+
+        if (actuallyRead < 1 && bytesToRead > actuallyRead) {
+            // was meant to read more bytes, but actually read nothing ??
+            String msg = "No bytes were read when expecting to read more! Memory path is "
+                    + memFile + ".";
+            throw new MemoryReadException(msg);
+        }
+
+        if (actuallyRead < bytesToRead) {
+            // managed to read fewer bytes than expecting, trim array
+            return Utilities.copyToFittedArray(bytes, actuallyRead);
+        }
+
+        return bytes;
+    }
+
+    private File getProcessMemFile(NativeProcess process) {
+        Path mem = procRoot.resolve(Paths.get(process.getPid()+"", PROC_MEM_FILENAME));
+        return mem.toFile();
+    }
+}

--- a/lacuna/src/main/java/cx/corp/lacuna/core/windows/WindowsNativeProcessEnumerator.java
+++ b/lacuna/src/main/java/cx/corp/lacuna/core/windows/WindowsNativeProcessEnumerator.java
@@ -5,6 +5,7 @@ import com.sun.jna.ptr.IntByReference;
 import cx.corp.lacuna.core.NativeProcessEnumerator;
 import cx.corp.lacuna.core.NativeProcess;
 import cx.corp.lacuna.core.ProcessEnumerationException;
+import cx.corp.lacuna.core.common.Utilities;
 import cx.corp.lacuna.core.windows.winapi.Advapi32;
 import cx.corp.lacuna.core.windows.winapi.Kernel32;
 import cx.corp.lacuna.core.windows.winapi.Psapi;
@@ -33,7 +34,7 @@ public class WindowsNativeProcessEnumerator implements NativeProcessEnumerator {
         int[] pidBuffer = createMaxSizePidBuffer();
         int pidCount = enumerateProcesses(pidBuffer);
         // Trim the unused array values. Well, copy them to a smaller array.
-        return copyToFittedArray(pidBuffer, pidCount);
+        return Utilities.copyToFittedArray(pidBuffer, pidCount);
     }
 
     private int[] createMaxSizePidBuffer() {
@@ -51,12 +52,6 @@ public class WindowsNativeProcessEnumerator implements NativeProcessEnumerator {
 
     private int byteCountToIntCount(int bytes) {
         return bytes / WinApiConstants.SIZEOF_INT;
-    }
-
-    private int[] copyToFittedArray(int[] array, int actualCount) {
-        int[] fittedArray = new int[actualCount];
-        System.arraycopy(array, 0, fittedArray, 0, actualCount);
-        return fittedArray;
     }
 
     private List<NativeProcess> constructProcessModels(int[] pids) {


### PR DESCRIPTION
https://trello.com/c/rEux0KR6

Reading process memory on Linux is implemented by reading from /proc/$pid/mem. Accessing other processess' memory on Linux platforms requires users to run lacuna with sudo rights. This is because access to /proc/$pid/mem is restricted from other processes.

If `/proc/sys/kernel/yama/ptrace_scope` is set to 0, it is possible to read another process' memory without sudo by first calling `ptrace(PTRACE_ATTACH, pid, NULL, NULL)` and then `waitpid(pid, NULL, 0)` to attach to the target process. This is what, for example, gdb does.

However, ptrace_scope is set to 1 by default, which restricts ptrace to child processes only. It is less dangerous for users to run lacuna with sudo than to mess with ptrace_scope, which is a system-wide setting.

Another workaround would be to grant the java binary ptrace capabilities with `sudo setcap cap_sys_ptrace=eip /path/to/java`, but if the executable is granted capabilities, the kernel binary loader will require all of java's dependency shared libraries to reside in trusted paths, or loading them will
fail with "not found". There is a workaround for *that* issue, but now we're doing workarounds for workarounds so it's time to agree that it's easier to just have the user `sudo` our program.

It would be possible to actually start the target executable as a child process in Java, but that's out of scope for this project right now.

Futher reading:
* [_What is the 'ptrace_scope' workaround ..._](http://askubuntu.com/a/153970/537513)
* [About PTRACE_ATTACH failing](http://stackoverflow.com/a/10163848/996081)
* man ptrace(2)
* [_How to get Oracle java 7 to work with setcap ..._](http://unix.stackexchange.com/q/87978)